### PR TITLE
Fixes ping names with '-' in table name conversion

### DIFF
--- a/sync/glean.py
+++ b/sync/glean.py
@@ -30,7 +30,7 @@ class GleanPing:
 
     @property
     def bigquery_table_name(self) -> str:
-        return self.name + "_v1"  # TODO: Update this to get the right ping version
+        return self.name.replace("-", "_") + "_v1"  # TODO: Update this to get the right ping version
 
     @property
     def bigquery_fully_qualified_names(self) -> Sequence[str]:


### PR DESCRIPTION
Table `addresses-sync_v1` for example should be `addresses_sync_v1`