### PR TITLE
DENG-731 - Stale Entity Removal for Glean and Legacy Telemetry

### DIFF
--- a/recipes/glean_recipe.dhub.yaml
+++ b/recipes/glean_recipe.dhub.yaml
@@ -2,6 +2,10 @@ source:
   type: sync.datahub.glean_source.GleanSource
   config:
     env: "PROD"
+    stateful_ingestion:
+      enabled: true
+
+pipeline_name: "glean_ingestion_pipeline"
 
 sink:
   type: "datahub-rest"

--- a/recipes/legacy_recipe.dhub.yaml
+++ b/recipes/legacy_recipe.dhub.yaml
@@ -2,6 +2,10 @@ source:
   type: sync.datahub.legacy_source.LegacySource
   config:
     env: "PROD"
+    stateful_ingestion:
+      enabled: true
+
+pipeline_name: "legacy_telemetry_ingestion_pipeline"
 
 sink:
   type: "datahub-rest"


### PR DESCRIPTION
Adds stale entity removal to Glean and Legacy telemetry ingestion. Mostly following this tutorial: https://datahubproject.io/docs/metadata-ingestion/docs/dev_guides/add_stateful_ingestion_to_source