### PR TITLE
Schedule glean and legacy telemetry recipes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,33 +15,23 @@ jobs:
       - run:
           name: Run tests
           command: python -m pytest
-  glean-source:
+  datahub-ingest:
     executor:
       name: python/default
       tag: 3.10.10
+    parameters:
+      recipe:
+        type: string
+        description: Repository path to the source recipe
     steps:
       - checkout
       - python/install-packages:
           pkg-manager: pip
-      - &set_env 
-        run:
-          name: "Set environment variables"
-          command: echo 'export DATAHUB_GMS_URL="https://mozilla.acryl.io/gms"' >> "$BASH_ENV"
       - run:
-          name: Sync Glean Pings
-          command: datahub ingest -c recipes/glean_recipe.dhub.yaml
-  legacytelemetry-source:
-    executor:
-      name: python/default
-      tag: 3.10.10
-    steps:
-      - checkout
-      - python/install-packages:
-          pkg-manager: pip
-      - *set_env
-      - run:
-          name: Sync Legacy Telemetry Pings
-          command: datahub ingest -c recipes/legacy_recipe.dhub.yaml
+          name: Sync Datahub source
+          command: |
+            export DATAHUB_GMS_URL="https://mozilla.acryl.io/gms"
+            datahub ingest -c << parameters.recipe >>
 
 workflows:
   ci:
@@ -50,10 +40,14 @@ workflows:
   nightly:  # Sync custom integration sources
     jobs:
       - unit-tests
-      - glean-source:
+      - datahub-ingest:
+          name: glean-source
+          recipe: recipes/glean_recipe.dhub.yaml
           requires:
             - unit-tests
-      - legacytelemetry-source:
+      - datahub-ingest:
+          name: legacytelemetry-source
+          recipe: recipes/legacy_recipe.dhub.yaml
           requires:
             - unit-tests
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,46 @@ jobs:
       - run:
           name: Run tests
           command: python -m pytest
+  glean-source:
+    executor:
+      name: python/default
+      tag: 3.10.10
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: pip
+      - run:
+          name: Sync Glean Pings
+          command: datahub ingest -c recipes/glean_recipe.dhub.yaml
+  legacytelemetry-source:
+    executor:
+      name: python/default
+      tag: 3.10.10
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: pip
+      - run:
+          name: Sync Legacy Telemetry Pings
+          command: datahub ingest -c recipes/legacy_recipe.dhub.yaml
 
 workflows:
   ci:
     jobs:
       - unit-tests
+  nightly:  # Sync custom integration sources
+    jobs:
+      - unit-tests
+      - glean-source:
+          requires:
+            - unit-tests
+      - legacytelemetry-source:
+          requires:
+            - unit-tests
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  python: circleci/python@1.5.0
+  python: circleci/python@2.1.1
 
 jobs:
   unit-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,10 @@ jobs:
       - checkout
       - python/install-packages:
           pkg-manager: pip
+      - &set_env 
+        run:
+          name: "Set environment variables"
+          command: echo 'export DATAHUB_GMS_URL="https://mozilla.acryl.io/gms"' >> "$BASH_ENV"
       - run:
           name: Sync Glean Pings
           command: datahub ingest -c recipes/glean_recipe.dhub.yaml
@@ -34,6 +38,7 @@ jobs:
       - checkout
       - python/install-packages:
           pkg-manager: pip
+      - *set_env
       - run:
           name: Sync Legacy Telemetry Pings
           command: datahub ingest -c recipes/legacy_recipe.dhub.yaml


### PR DESCRIPTION
Nightly CI job to run glean and legacy telemetry ingestion. Also update to use latest python orb.