### PR TITLE
Run with python -m, Comment legacy telemetry source

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,11 +45,6 @@ workflows:
           recipe: recipes/glean_recipe.dhub.yaml
           requires:
             - unit-tests
-      # - datahub-ingest:
-      #     name: legacytelemetry-source
-      #     recipe: recipes/legacy_recipe.dhub.yaml
-      #     requires:
-      #       - unit-tests
     triggers:
       - schedule:
           cron: "0 0 * * *"


### PR DESCRIPTION
To include module in the `PYTHONPATH` and pause legacy telemetry until we can fix the state issue