### PR TITLE
Schedule ping recipes without stateful ingestion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,11 @@ workflows:
           recipe: recipes/glean_recipe.dhub.yaml
           requires:
             - unit-tests
+      - datahub-ingest:
+          name: legacytelemetry-source
+          recipe: recipes/legacy_recipe.dhub.yaml
+          requires:
+            - unit-tests
     triggers:
       - schedule:
           cron: "0 0 * * *"

--- a/recipes/glean_recipe.dhub.yaml
+++ b/recipes/glean_recipe.dhub.yaml
@@ -3,7 +3,7 @@ source:
   config:
     env: "PROD"
     stateful_ingestion:
-      enabled: true
+      enabled: false
 
 pipeline_name: "glean_ingestion_pipeline"
 

--- a/recipes/legacy_recipe.dhub.yaml
+++ b/recipes/legacy_recipe.dhub.yaml
@@ -3,7 +3,7 @@ source:
   config:
     env: "PROD"
     stateful_ingestion:
-      enabled: true
+      enabled: false
 
 pipeline_name: "legacy_telemetry_ingestion_pipeline"
 


### PR DESCRIPTION
We seem to have some incorrect state in our instance causing ingestion failures such as [this](https://app.circleci.com/pipelines/github/mozilla/mozilla-datahub-ingestion/68/workflows/36aaed76-7623-4186-b343-186cec4a1a44/jobs/86). Ingestion runs correctly without stateful ingestion/stale entity removal enabled so we can schedule it here. 

I'll reopen the ticket related to stateful ingestion and move it to On Hold for when we'd like to revisit this https://mozilla-hub.atlassian.net/browse/DENG-731 