### PR TITLE
Replace Glean logo

### DIFF
--- a/recipes/platform_mce.json
+++ b/recipes/platform_mce.json
@@ -11,7 +11,7 @@
               "name": "Glean",
               "displayName": "Glean Telemetry",
               "type": "OTHERS",
-              "logoUrl": "https://raw.githubusercontent.com/mozilla/glean-dictionary/main/public/glean_logo.png"
+              "logoUrl": "https://raw.githubusercontent.com/mozilla/glean-dictionary/main/public/img/app-logos/glean.png"
             }
           }
         ]


### PR DESCRIPTION
Replace with a smaller logo so it doesn't eat up as much real estate.