### PR TITLE
Require unit-tests in CI before syncing Metric-Hub to Glossary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,8 @@ workflows:
             - run:
                 name: Generate Metric-Hub Glossary YAML
                 command: python -m sync.datahub.metrichub_glossary
+          requires:
+            - unit-tests
       - datahub-ingest:
           name: bigquery-etl-source
           recipe: recipes/bigquery_etl_recipe.dhub.yaml


### PR DESCRIPTION
Similar to other glossary jobs.