### PR TITLE
Add Looker links to metric-hub metrics

### DIFF
--- a/sync/datahub/metrichub_glossary.py
+++ b/sync/datahub/metrichub_glossary.py
@@ -31,7 +31,7 @@ def _build_metric_dict(metric: MetricHubDefinition) -> Dict:
     if metric.sql_definition:
         metric_content += f"SQL Definition:\n```{metric.sql_definition.strip()}```\n\n"
 
-    if metric.statistics and len(metric.statistics) > 0:
+    if metric.statistics:
         metric_content += "Explore this metric in Looker:\n"
         metric_content += "\n".join(_get_looker_statistics_links(metric))
 

--- a/sync/datahub/metrichub_glossary.py
+++ b/sync/datahub/metrichub_glossary.py
@@ -29,7 +29,11 @@ def _build_metric_dict(metric: MetricHubDefinition) -> Dict:
         metric_content += f"_{metric.description.strip()}_\n\n"
 
     if metric.sql_definition:
-        metric_content += f"SQL Definition:\n```{metric.sql_definition.strip()}```"
+        metric_content += f"SQL Definition:\n```{metric.sql_definition.strip()}```\n\n"
+
+    if metric.statistics and len(metric.statistics) > 0:
+        metric_content += "Explore this metric in Looker:\n"
+        metric_content += "\n".join(_get_looker_statistics_links(metric))
 
     return {
         "id": metric.urn,
@@ -55,6 +59,22 @@ def _get_metric_level_link_text(level: MetricLevel) -> str:
         return ""
 
     return f"[{text}]({url}/{urn})\n\n"
+
+
+def _get_looker_statistics_links(metric: MetricHubDefinition) -> List[str]:
+    url = "https://mozilla.cloud.looker.com/explore"
+    links = []
+
+    for statistic in metric.statistics:
+        if metric.data_source is not None:
+            explore = f"metric_definitions_{metric.data_source}"
+            fields = ",".join(["submission_date", f"{metric.name}_{statistic.name}"])
+            title = f"{metric.title_cased_name} {statistic.title_cased_name}"
+            links.append(
+                f"[{title}]({url}/{metric.product}/{explore}?fields={fields}&toggle=vis)"
+            )
+
+    return links
 
 
 def _build_product_dict(product: str, metrics: List[MetricHubDefinition]) -> Dict:

--- a/sync/metrichub.py
+++ b/sync/metrichub.py
@@ -13,6 +13,15 @@ LOOKER_METRICS_URL = "https://github.com/mozilla/metric-hub/tree/main/looker"
 
 @dataclass
 class MetricStatistic:
+    """
+    Defines and aggregation of a metric across a specific population.
+
+    Metric-hub allows users to specify statistics on top of metrics.
+    Statistics summarize the distribution of metrics within a specific
+    time frame and population segment. These statistics allow for basic
+    analyses of a metric and are represented in Looker as measures.
+    """
+
     name: str
 
     @property
@@ -55,8 +64,8 @@ class MetricHubDefinition:
         return f"{make_term_urn(f'Metric Hub.{self.product}.{self.name}')}"
 
     @property
-        def title_cased_name(self) -> str:
-            return self.name.replace("_", " ").title()
+    def title_cased_name(self) -> str:
+        return self.name.replace("_", " ").title()
 
 
 def _raw_table_name(table: sqlglot.exp.Table) -> str:


### PR DESCRIPTION
This is adding some links to explore metrics in Looker.

![Screenshot 2024-03-11 at 11 30 11 AM](https://github.com/mozilla/mozilla-datahub-ingestion/assets/1239705/9ef70652-47a1-4a82-81c0-546cf8541796)
