### PR TITLE
Use stable URNs for metric-hub glossary terms

### DIFF
--- a/sync/datahub/metrichub_glossary.py
+++ b/sync/datahub/metrichub_glossary.py
@@ -32,6 +32,7 @@ def _build_metric_dict(metric: MetricHubDefinition) -> Dict:
         metric_content += f"SQL Definition:\n```{metric.sql_definition.strip()}```"
 
     return {
+        "id": metric.urn,
         "name": metric.display_name,
         "description": metric_content,
         "owners": {"users": metric.owners},

--- a/sync/metrichub.py
+++ b/sync/metrichub.py
@@ -1,4 +1,5 @@
 import re
+from datahub.emitter.mce_builder import make_term_urn
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -36,6 +37,10 @@ class MetricHubDefinition:
                 metric_name += " 🥉"
 
         return metric_name
+
+    @property
+    def urn(self) -> str:
+        return f"{make_term_urn(f'Metric Hub.{self.product}.{self.name}')}"
 
 
 def _raw_table_name(table: sqlglot.exp.Table) -> str:


### PR DESCRIPTION
Keep the glossary term URNs consistent even if the metric display name changes.

We'll need to manually delete the duplicated terms after this gets merged.

cc @jmsilverman