### PR TITLE
Clean up some Datahub formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The local DataHub instance can by default be accessed via: http://localhost:9002
 
 2. Activate the virtual environment: `$ source venv/bin/activate`
 
-3. Install project dependencies: `$ pip install -r requirements.txt`. This should include the [DataHub CLI](https://datahubproject.io/docs/quickstart/).
+3. Install project dependencies: `$ pip install -r requirements.txt`. If this fails, you can install the requirements automatically line-by-line (letting the failing ones fail): `pip freeze | sed -e '/^\s*#.*$/d' -e '/^\s*$/d' | xargs -n 1 pip install (step 2a if 2 fails)`. This should include the [DataHub CLI](https://datahubproject.io/docs/quickstart/).
 
 4. Install the module locally: `$ pip install -e .`
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ The local DataHub instance can by default be accessed via: http://localhost:9002
 ### Setup
 1. Create a virtual environment: `$ python -m venv venv`
 
-2. Install project dependencies: `$ pip install -r requirements.txt`. This should include the [DataHub CLI](https://datahubproject.io/docs/quickstart/).
+2. Activate the virtual environment: `$ source venv/bin/activate`
 
-3. Install the module locally: `$ pip install -e .`
+3. Install project dependencies: `$ pip install -r requirements.txt`. This should include the [DataHub CLI](https://datahubproject.io/docs/quickstart/).
+
+4. Install the module locally: `$ pip install -e .`
 
 
 ### Linting

--- a/recipes/metrichub_recipe.dhub.yaml
+++ b/recipes/metrichub_recipe.dhub.yaml
@@ -1,4 +1,4 @@
-# Build the YAML configuration file before running the ingestion: `python3 -m sync.datahub.metrichub_glossary.py`
+# Build the YAML configuration file before running the ingestion: `python3 -m sync.datahub.metrichub_glossary`
 source:
   type: datahub-business-glossary
   config:


### PR DESCRIPTION
This PR will clean up some Datahub formatting such as:
- Underscores used for italics of Metric Descriptions aren't rendering properly so let's remove those
- SQL queries as code blocks are not rendering properly, so we need to add some newlines and we'll tag the code as SQL to get the code highlighting
- Boldify some section titles
- Metric Descriptions' new lines from the source code are being treated literally so let's replace those with just spaces

Some other typos and info in the README and comments are also updated in this PR.