### PR TITLE
Clean up Datahub MetricHub formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ The local DataHub instance can by default be accessed via: http://localhost:9002
 ### Setup
 1. Create a virtual environment: `$ python -m venv venv`
 
-2. Install project dependencies: `$ pip install -r requirements.txt`. This should include the [DataHub CLI](https://datahubproject.io/docs/quickstart/).
+2. Activate the virtual environment: `$ source venv/bin/activate`
 
-3. Install the module locally: `$ pip install -e .`
+3. Install project dependencies: `$ pip install -r requirements.txt`. If this fails, you can install the requirements automatically line-by-line (letting the failing ones fail): `pip freeze | sed -e '/^\s*#.*$/d' -e '/^\s*$/d' | xargs -n 1 pip install (step 2a if 2 fails)`. This should include the [DataHub CLI](https://datahubproject.io/docs/quickstart/).
+
+4. Install the module locally: `$ pip install -e .`
 
 
 ### Linting

--- a/recipes/metrichub_recipe.dhub.yaml
+++ b/recipes/metrichub_recipe.dhub.yaml
@@ -1,4 +1,4 @@
-# Build the YAML configuration file before running the ingestion: `python3 -m sync.datahub.metrichub_glossary.py`
+# Build the YAML configuration file before running the ingestion: `python3 -m sync.datahub.metrichub_glossary`
 source:
   type: datahub-business-glossary
   config:

--- a/sync/datahub/metrichub_glossary.py
+++ b/sync/datahub/metrichub_glossary.py
@@ -1,6 +1,7 @@
 """Builds the metric-hub glossary YAML file for syncing to DataHub."""
 import itertools
 import operator
+from os import linesep
 from typing import Dict, List
 from metric_config_parser.metric import MetricLevel
 from datahub.emitter.mce_builder import make_term_urn
@@ -23,16 +24,16 @@ def _build_metric_dict(metric: MetricHubDefinition) -> Dict:
         metric_content += "⚠️ **This metric has been deprecated**\n\n"
 
     if metric.level:
-        metric_content += f"Metric Level: {_get_metric_level_link_text(metric.level)}"
+        metric_content += f"**Metric Level:** {_get_metric_level_link_text(metric.level)}"
 
     if metric.description:
-        metric_content += f"_{metric.description.strip()}_\n\n"
+        metric_content += f"{metric.description.strip().replace(linesep, ' ')}\n\n"
 
     if metric.sql_definition:
-        metric_content += f"SQL Definition:\n```{metric.sql_definition.strip()}```\n\n"
+        metric_content += f"**SQL Definition:**\n```sql\n{metric.sql_definition.strip()}\n```\n\n"
 
     if metric.statistics:
-        metric_content += "Explore this metric in Looker:\n"
+        metric_content += "**Explore this metric in Looker:**\n"
         metric_content += "\n".join(_get_looker_statistics_links(metric))
 
     return {


### PR DESCRIPTION
This PR will clean up some Datahub formatting such as:
- Underscores used for italics of Metric Descriptions aren't rendering properly so let's remove those
- SQL queries as code blocks are not rendering properly, so we need to add some newlines and we'll tag the code as SQL to get the code highlighting
- Boldify some section titles
- Metric Descriptions' new lines from the source code are being treated literally so let's replace those with just spaces

Some other typos and info in the README and comments are also updated in this PR.