### PR TITLE
Clean Up Datahub Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ The local DataHub instance can by default be accessed via: http://localhost:9002
 ### Setup
 1. Create a virtual environment: `$ python -m venv venv`
 
-2. Install project dependencies: `$ pip install -r requirements.txt`. This should include the [DataHub CLI](https://datahubproject.io/docs/quickstart/).
+2. Activate the virtual environment: `$ source venv/bin/activate`
 
-3. Install the module locally: `$ pip install -e .`
+3. Install project dependencies: `$ pip install -r requirements.txt`. This should include the [DataHub CLI](https://datahubproject.io/docs/quickstart/).
+
+4. Install the module locally: `$ pip install -e .`
 
 
 ### Linting

--- a/recipes/metrichub_recipe.dhub.yaml
+++ b/recipes/metrichub_recipe.dhub.yaml
@@ -1,4 +1,4 @@
-# Build the YAML configuration file before running the ingestion: `python3 -m sync.datahub.metrichub_glossary.py`
+# Build the YAML configuration file before running the ingestion: `python3 -m sync.datahub.metrichub_glossary`
 source:
   type: datahub-business-glossary
   config:

--- a/sync/datahub/metrichub_glossary.py
+++ b/sync/datahub/metrichub_glossary.py
@@ -35,11 +35,6 @@ def _build_metric_dict(metric: MetricHubDefinition) -> Dict:
     if metric.sql_definition:
         metric_content += f"**SQL Definition:**\n```sql\n{metric.sql_definition.strip()}\n```\n\n"
 
-    if metric.data_source:
-        # FIXME: It would be nice to link to the dataset page in datahub (via metric.data_source) 
-        #        or to the BQ table(s) (via metric.bigquery_tables)
-        metric_content += f"**Data Source:** {metric.data_source} {metric.bigquery_tables}\n\n"
-
     if metric.statistics:
         metric_content += "**Explore this metric in Looker:**\n"
         metric_content += "\n".join(_get_looker_statistics_links(metric))

--- a/sync/datahub/metrichub_glossary.py
+++ b/sync/datahub/metrichub_glossary.py
@@ -20,12 +20,12 @@ GLOSSARY_FILENAME = "metric_hub_glossary.yaml"
 def _build_metric_dict(metric: MetricHubDefinition) -> Dict:
     metric_content = ""
 
-    # if metric.data_source:
-    #     metric_content += f"# {metric.data_source} \n\n"
-
     if metric.deprecated:
-        metric_content += "### ⚠️ **This metric has been deprecated**\n\n"
+        metric_content += "#### ⚠️ **This metric has been deprecated**\n\n"
 
+    if metric.friendly_name:
+        metric_content += f"## {metric.friendly_name} \n\n"
+    
     if metric.level:
         metric_content += f"**Metric Level:** {_get_metric_level_link_text(metric.level)}\n\n"
 
@@ -36,7 +36,9 @@ def _build_metric_dict(metric: MetricHubDefinition) -> Dict:
         metric_content += f"**SQL Definition:**\n```sql\n{metric.sql_definition.strip()}\n```\n\n"
 
     if metric.data_source:
-        metric_content += f"**Data Source:** {metric.data_source}\n\n"
+        # FIXME: It would be nice to link to the dataset page in datahub (via metric.data_source) 
+        #        or to the BQ table(s) (via metric.bigquery_tables)
+        metric_content += f"**Data Source:** {metric.data_source} {metric.bigquery_tables}\n\n"
 
     if metric.statistics:
         metric_content += "**Explore this metric in Looker:**\n"

--- a/sync/datahub/metrichub_glossary.py
+++ b/sync/datahub/metrichub_glossary.py
@@ -109,10 +109,10 @@ def main() -> None:
     ]
 
     glossary = {
-        "version": '1', # 1, ## int led to "validation error for BusinessGlossaryConfig"
+        "version": 1,
         "source": "Metric-Hub",
         "url": METRIC_HUB_REPO_URL,
-        "owners": {}, # [], ## list led to "validation error for BusinessGlossaryConfig"
+        "owners": [],
         "nodes": [
             {
                 "name": "Metric Hub",

--- a/sync/datahub/metrichub_glossary.py
+++ b/sync/datahub/metrichub_glossary.py
@@ -1,6 +1,7 @@
 """Builds the metric-hub glossary YAML file for syncing to DataHub."""
 import itertools
 import operator
+from os import linesep
 from typing import Dict, List
 from metric_config_parser.metric import MetricLevel
 from datahub.emitter.mce_builder import make_term_urn
@@ -23,16 +24,16 @@ def _build_metric_dict(metric: MetricHubDefinition) -> Dict:
         metric_content += "⚠️ **This metric has been deprecated**\n\n"
 
     if metric.level:
-        metric_content += f"Metric Level: {_get_metric_level_link_text(metric.level)}"
+        metric_content += f"**Metric Level:** {_get_metric_level_link_text(metric.level)}"
 
     if metric.description:
-        metric_content += f"_{metric.description.strip()}_\n\n"
+        metric_content += f"{metric.description.strip().replace(linesep, ' ')}\n\n"
 
     if metric.sql_definition:
-        metric_content += f"SQL Definition:\n```{metric.sql_definition.strip()}```\n\n"
+        metric_content += f"**SQL Definition:**\n```sql\n{metric.sql_definition.strip()}\n```\n\n"
 
     if metric.statistics:
-        metric_content += "Explore this metric in Looker:\n"
+        metric_content += "**Explore this metric in Looker:**\n"
         metric_content += "\n".join(_get_looker_statistics_links(metric))
 
     return {
@@ -100,10 +101,10 @@ def main() -> None:
     ]
 
     glossary = {
-        "version": 1,
+        "version": '1', # 1, ## int led to "validation error for BusinessGlossaryConfig"
         "source": "Metric-Hub",
         "url": METRIC_HUB_REPO_URL,
-        "owners": [],
+        "owners": {}, # [], ## list led to "validation error for BusinessGlossaryConfig"
         "nodes": [
             {
                 "name": "Metric Hub",

--- a/sync/datahub/metrichub_glossary.py
+++ b/sync/datahub/metrichub_glossary.py
@@ -20,17 +20,23 @@ GLOSSARY_FILENAME = "metric_hub_glossary.yaml"
 def _build_metric_dict(metric: MetricHubDefinition) -> Dict:
     metric_content = ""
 
+    # if metric.data_source:
+    #     metric_content += f"# {metric.data_source} \n\n"
+
     if metric.deprecated:
-        metric_content += "⚠️ **This metric has been deprecated**\n\n"
+        metric_content += "### ⚠️ **This metric has been deprecated**\n\n"
 
     if metric.level:
-        metric_content += f"**Metric Level:** {_get_metric_level_link_text(metric.level)}"
+        metric_content += f"**Metric Level:** {_get_metric_level_link_text(metric.level)}\n\n"
 
     if metric.description:
         metric_content += f"{metric.description.strip().replace(linesep, ' ')}\n\n"
 
     if metric.sql_definition:
         metric_content += f"**SQL Definition:**\n```sql\n{metric.sql_definition.strip()}\n```\n\n"
+
+    if metric.data_source:
+        metric_content += f"**Data Source:** {metric.data_source}\n\n"
 
     if metric.statistics:
         metric_content += "**Explore this metric in Looker:**\n"

--- a/sync/metrichub.py
+++ b/sync/metrichub.py
@@ -40,6 +40,7 @@ class MetricHubDefinition:
     bigquery_tables: Optional[List[str]]
     data_source: Optional[str]
     statistics: Optional[List[MetricStatistic]]
+    friendly_name: Optional[str]
     deprecated: bool = False
 
     @property
@@ -165,6 +166,10 @@ def get_metric_definitions() -> List[MetricHubDefinition]:
                 for statistic_name, _ in metric.statistics.items():
                     statistics.append(MetricStatistic(name=statistic_name))
 
+            ###
+            metric.level=MetricLevel.GOLD
+            ###
+
             metrics.append(
                 MetricHubDefinition(
                     name=metric.name,
@@ -173,6 +178,7 @@ def get_metric_definitions() -> List[MetricHubDefinition]:
                     if isinstance(metric.owner, str)
                     else metric.owner,
                     level=metric.level.value if metric.level else None,
+                    friendly_name=metric.friendly_name or False,
                     deprecated=metric.deprecated or False,
                     sql_definition=metric.select_expression,
                     product=definition.platform,

--- a/sync/metrichub.py
+++ b/sync/metrichub.py
@@ -174,7 +174,7 @@ def get_metric_definitions() -> List[MetricHubDefinition]:
                     if isinstance(metric.owner, str)
                     else metric.owner,
                     level=metric.level.value if metric.level else None,
-                    friendly_name=metric.friendly_name or False,
+                    friendly_name=metric.friendly_name if metric.friendly_name else None,
                     deprecated=metric.deprecated or False,
                     sql_definition=metric.select_expression,
                     product=definition.platform,

--- a/sync/metrichub.py
+++ b/sync/metrichub.py
@@ -166,10 +166,6 @@ def get_metric_definitions() -> List[MetricHubDefinition]:
                 for statistic_name, _ in metric.statistics.items():
                     statistics.append(MetricStatistic(name=statistic_name))
 
-            ###
-            metric.level=MetricLevel.GOLD
-            ###
-
             metrics.append(
                 MetricHubDefinition(
                     name=metric.name,


### PR DESCRIPTION
There are some formatting weirdnesses in Datahub when going from the metric-hub source code to yaml as parsed by Datahub. This PR:
- Boldifies some field headings in the Metric Description to make them easier to read
- Removes underscores that were supposed to italicize the main Metric Description but that often broke
- Replaces linebreaks in Metric Descriptions with spaces to make them easier to read
- Adds necessary line breaks in code block of SQL Definition so all text is displayed
- Adds `sql` tag to SQL Definition code blocks to utilize code highlighting

This PR also surfaces the `friendly_name` field as the title/heading in the metric's description, as well as the `data_source` and `bigquery_tables` fields (though it would be nice to have one or both of those link out to datahub or BQ, respectively, I just couldn't figure out how to do that).

Lastly, this PR also makes a few small edits to comments & documentation.