### PR TITLE
Make sure to set GMS url before calling upsert

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,9 @@ workflows:
                 command: python -m sync.datahub.metrichub_glossary
             - run:
                 name: Connect Glossary Terms to Tables
-                command: python -m datahub dataset upsert -f datasets.yaml
+                command: |
+                  export DATAHUB_GMS_URL="https://mozilla.acryl.io/gms"
+                  python -m datahub dataset upsert -f datasets.yaml
           requires:
             - unit-tests
       - datahub-ingest:


### PR DESCRIPTION
Fix the current CI failure in the [`nightly`](https://app.circleci.com/pipelines/github/mozilla/mozilla-datahub-ingestion/649/workflows/4c631483-9de4-4566-86c3-9353b5f18a7e) workflow.