### PR TITLE
Fix metric levels in metric names

### DIFF
--- a/sync/metrichub.py
+++ b/sync/metrichub.py
@@ -175,7 +175,7 @@ def get_metric_definitions() -> List[MetricHubDefinition]:
                         if isinstance(metric.owner, str)
                         else metric.owner
                     ),
-                    level=metric.level.value if metric.level else None,
+                    level=metric.level if metric.level else None,
                     friendly_name=(
                         metric.friendly_name if metric.friendly_name else None
                     ),


### PR DESCRIPTION
Fixes https://mozilla-hub.atlassian.net/browse/DO-1799

The Datahub logic is checking for `MetricLevel` enums instead of the string values: https://github.com/mozilla/mozilla-datahub-ingestion/blob/7a7a90a94b10228c4cc68e0fd880ccd9f32e00f9/sync/metrichub.py#L54