### PR TITLE
Revert "Increased bqetl column limit"

### DIFF
--- a/recipes/bigquery_etl_recipe.dhub.yaml
+++ b/recipes/bigquery_etl_recipe.dhub.yaml
@@ -2,7 +2,6 @@ source:
   type: sync.datahub.bigquery_etl_source.BigQueryEtlSource
   config:
     env: "PROD"
-    column_limit: 4000
 
 sink:
   type: "datahub-rest"


### PR DESCRIPTION
Reverts mozilla/mozilla-datahub-ingestion#164

This resulted in main failing:  https://app.circleci.com/pipelines/github/mozilla/mozilla-datahub-ingestion/929/workflows/c3951f93-a046-4d44-ae04-41b0a06a6463/jobs/2923

reverting this for now while I connect with acryl for more help