### PR TITLE
Revert "Increased column limit"

### DIFF
--- a/recipes/bigquery_etl_recipe.dhub.yaml
+++ b/recipes/bigquery_etl_recipe.dhub.yaml
@@ -2,7 +2,7 @@ source:
   type: sync.datahub.bigquery_etl_source.BigQueryEtlSource
   config:
     env: "PROD"
-    column_limit: 4500
+    column_limit: 4000
 
 sink:
   type: "datahub-rest"

--- a/sync/datahub/bigquery_etl_source.py
+++ b/sync/datahub/bigquery_etl_source.py
@@ -17,7 +17,7 @@ from sync.datahub.utils import get_current_timestamp
 
 class BigQueryEtlSourceConfig(ConfigModel):
     env: str = "PROD"
-    column_limit: int = 4500
+    column_limit: int = 4000
 
 
 class BigQueryEtlSource(Source):


### PR DESCRIPTION
Reverts mozilla/mozilla-datahub-ingestion#174

The column_limit should be added to BigQuery ingestion instead.